### PR TITLE
display the name of the current file in the viewer

### DIFF
--- a/in.js
+++ b/in.js
@@ -201,12 +201,13 @@ const ZIP = require("zip");
         }
     }
 
-    function getViewerIframe() {
+    function getViewerIframe(name) {
         // in chrome, image → rtf navigations in iframes seem to be buggy,
         // so destroy and create the iframe anew each time we view something
         const viewer = document.querySelector("#viewer");
-        viewer.innerHTML = `<iframe src="about:blank"></iframe>`;
-        return viewer.firstChild;
+        viewer.innerHTML = `<strong></strong><iframe src="about:blank"></iframe>`;
+        viewer.childNodes[0].innerText = name;
+        return viewer.childNodes[1];
     }
 
     function addRtfDocument(parent, name, buffer) {
@@ -220,7 +221,7 @@ const ZIP = require("zip");
             console.log(rtf.metadata());
             const elements = await rtf.render();
 
-            const iframe = getViewerIframe();
+            const iframe = getViewerIframe(name);
             iframe.contentDocument.open();
 
             // remove big margins for readability
@@ -240,7 +241,7 @@ const ZIP = require("zip");
         a.href = "#";
         a.addEventListener("click", event => {
             event.preventDefault();
-            const iframe = getViewerIframe();
+            const iframe = getViewerIframe(name);
 
             if (!zipped) {
                 iframe.src = makeBlobUrl(buffer, type);
@@ -264,7 +265,7 @@ const ZIP = require("zip");
         a.href = "#";
         a.addEventListener("click", event => {
             event.preventDefault();
-            const iframe = getViewerIframe();
+            const iframe = getViewerIframe(name);
 
             const element = iframe.contentDocument.createElement("a");
             element.href = makeBlobUrl(buffer, "application/octet-stream");


### PR DESCRIPTION
i'm so good at forgetting which file i've clicked in the files tab within mere seconds of pressing my mouse button. this makes greedily looking at all my files quite a chore! this is truly a dilemma.

this change displays the name of the file above the viewer iframe.

**📢 hey puppy, why not highlight the current file in the list instead?**
although this would be feasible, due to the current structure of the site it would require us to unhighlight the previously selected file before highlighting the current one. the state of the viewer is also entirely independent to the list, so this opens us up to potential desync.

**📢 hey puppyyy, why did you use a `<strong>`?**
all the heading tags were too big and had big margins. but strong is small and does not require significant personal space

**📢 hey puppyyyyy, why does the list say `rtf` and `pdf.zip.base64` and stuff, but the name in the viewer doesn't?**
that type string doesn't reach the function that actually adds the `<a>` that opens it in the viewer. that function is also what adds the click listener that populates the viewer. this felt too hard

meow meow bark woof meow 🐕